### PR TITLE
CLI Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ The simplest way to capture a screenshot and save it can look like this,
 Kleya.capture('https://www.hellotext.com').save
 ```
 
+Or directly via the CLI
+
+```bash
+kleya https://www.hellotext.com
+```
+
 ## Usage
 
 ```ruby
@@ -51,6 +57,27 @@ puts artifact.content_type  # "image/jpeg"
 # Clean up
 browser.quit
 ```
+
+## CLI Usage
+
+Kleya includes a command-line interface for quick screenshot captures:
+
+```bash
+# Basic usage
+kleya https://www.hellotext.com
+
+# With options
+kleya https://www.hellotext.com --format png --quality 95 --area page
+```
+
+CLI Options
+
+- `--format`, `-f` - Image format (jpeg, png). Default: jpeg
+- `--quality`, `-q` - Image quality (1-100). Default: 90
+- `--area`, `-a` - Capture area (viewport, page). Default: viewport
+- `--encoding`, `-e` - Output encoding (binary, base64). Default: base64
+- `--output`, `-o` - Output destination, defaults to the current directory.
+- `--help`, `-h` - Show help message
 
 ### Presets
 
@@ -187,7 +214,6 @@ end
 - Memory usage optimization for large batches
 - Request blocking (ads, analytics, fonts)
 
-- CLI tool for quick captures (`kleya capture https://example.com`)
 - Debug mode with browser preview
 - Capture metrics (timing, size, errors)
 

--- a/bin/kleya
+++ b/bin/kleya
@@ -1,0 +1,51 @@
+#!/usr/bin/env ruby
+
+require 'optparse'
+require 'kleya'
+
+options = {
+  format: :jpeg,
+  quality: 90,
+  area: :viewport,
+  encoding: :base64,
+  output: nil
+}
+
+parser = OptionParser.new do |opts|
+  opts.banner = 'Usage: kleya [url] [options]'
+
+  opts.on('-f', '--format FORMAT', [:jpeg, :png], 'Image format (jpeg, png)') do |format|
+    options[:format] = format
+  end
+
+  opts.on('-q', '--quality QUALITY', Integer, 'Image quality (0-100)') do |quality|
+    options[:quality] = quality
+  end
+
+  opts.on('-a', '--area AREA', [:viewport, :full], 'Area to capture (viewport, full)') do |area|
+    options[:area] = area
+  end
+
+  opts.on('-e', '--encoding ENCODING', [:base64, :binary], 'Encoding (base64, binary)') do |encoding|
+    options[:encoding] = encoding
+  end
+
+  opts.on('-o', '--output OUTPUT', String, 'Output file path') do |output|
+    options[:output] = output
+  end
+
+  opts.on('-h', '--help', 'Show this message') do
+    puts opts
+    exit
+  end
+end
+
+parser.parse!
+
+if ARGV.empty?
+  puts "Error: URL is required"
+  puts parser
+  exit 1
+end
+
+Kleya.capture(ARGV[0], **options).save(options[:output])

--- a/kleya.gemspec
+++ b/kleya.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'kleya'
-  s.version = '0.0.2'
+  s.version = '0.0.3'
   s.summary = 'Screenshots, made easy.'
   s.description = 'Screenshots, made easy.'
   s.authors = ['Hellotext', 'Ahmed Khattab']
@@ -17,4 +17,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'webmock', '~> 3.25'
 
   s.add_dependency 'ferrum', '~> 0.17'
+  s.executables << 'kleya'
 end

--- a/lib/kleya/artifact.rb
+++ b/lib/kleya/artifact.rb
@@ -39,6 +39,8 @@ module Kleya
         path = filename
       elsif File.directory?(path)
         path = File.join(path, filename)
+      elsif File.extname(path).empty?
+        path = "#{path}.#{@format}"
       end
 
       File.write(path, binary, mode: 'wb').then { path }

--- a/test/artifact_test.rb
+++ b/test/artifact_test.rb
@@ -11,6 +11,11 @@ class ArtifactTest < Minitest::Test
     )
   end
 
+  def teardown
+    FileUtils.rm_f('test.jpg')
+    FileUtils.rm_f('appends_extension.jpeg')
+  end
+
   def test_artifact_size
     assert_equal(4, @artifact.size)
   end
@@ -19,6 +24,16 @@ class ArtifactTest < Minitest::Test
     assert_runs_without_errors do
       @artifact.save('test.jpg')
     end
+
+    assert File.exist?('test.jpg')
+  end
+
+  def test_artifact_save_with_content_type_extension
+    assert_runs_without_errors do
+      @artifact.save('appends_extension')
+    end
+
+    assert File.exist?('appends_extension.jpeg')
   end
 
   def test_artifact_base64


### PR DESCRIPTION
Adds support for a CLI script with basic options to allow a quick way to capture directly without needing a script. Following options are accepted,

- `--format`, `-f` - Image format (jpeg, png). Default: jpeg
- `--quality`, `-q` - Image quality (1-100). Default: 90
- `--area`, `-a` - Capture area (viewport, page). Default: viewport
- `--encoding`, `-e` - Output encoding (binary, base64). Default: base64
- `--output`, `-o` - Output destination, defaults to the current directory.
- `--help`, `-h` - Show help message

### Examples 

```bash
# Basic usage
kleya https://www.hellotext.com

# With options
kleya https://www.hellotext.com --format png --quality 95 --area page
```

### Bugfixes 

- Fixes a small bug where if you provided a filename without an extension kleya would not have appended the correct extension, resulting in a corrupted file.